### PR TITLE
Fix missing props and css import

### DIFF
--- a/src/components/Mochila/styles.js
+++ b/src/components/Mochila/styles.js
@@ -1,4 +1,4 @@
-import styled, { keyframes } from 'styled-components';
+import styled, { keyframes, css } from 'styled-components';
 
 export const MochilaContainer = styled.div`
   display: flex;

--- a/src/components/SelectionGrid/index.jsx
+++ b/src/components/SelectionGrid/index.jsx
@@ -33,6 +33,7 @@ export const SelectionGrid = ({
     onAddItem, 
     onRemoveItem, 
     listName,
+    isEditing,
     onAddCustomItem,
     onUpdateCustomItem,
     onDeleteCustomItem

--- a/src/components/SheetFooter/index.jsx
+++ b/src/components/SheetFooter/index.jsx
@@ -20,7 +20,9 @@ import { TechniqueSelectionGrid } from '../TechniqueSelectionGrid';
 export const SheetFooter = ({
   isEditing, character, lockedItems, itemCounts, gameData,
   addItem, removeItem,
-  onAddTechnique, onRemoveTechnique, checkTechniqueRequirements, isBackstoryVisible
+  onAddTechnique, onRemoveTechnique, checkTechniqueRequirements, isBackstoryVisible,
+  setIsBackstoryVisible,
+  handleUpdate
 }) => {
   return (
     <FooterPanel>


### PR DESCRIPTION
## Summary
- add `isEditing` prop to `SelectionGrid`
- include `setIsBackstoryVisible` and `handleUpdate` props in `SheetFooter`
- import `css` helper in `Mochila` styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859899ce8c88325b0a70747c0325faf